### PR TITLE
Fix two TypeErrors that silently drop all streams from cb01 and eurostreaming

### DIFF
--- a/Src/API/cb01.py
+++ b/Src/API/cb01.py
@@ -222,12 +222,18 @@ async def cb01(streams,id,MFP,MFP_CREDENTIALS,client):
             season = general[2]
             episode = general[3]
             link = await search_series(showname,date,client)
+            if not link:
+                logger.info(f'CB01: no series match for {showname} ({date})')
+                return streams
             streams = await series_redirect_url(link,season,episode,client,MFP,MFP_CREDENTIALS,streams)
             return streams
         elif ismovie == 1:
             season = None
             episode = None
             link = await search_movie(showname,date,client)
+            if not link:
+                logger.info(f'CB01: no movie match for {showname} ({date})')
+                return streams
             streams = await movie_redirect_url(link,client,MFP,MFP_CREDENTIALS,streams)
             return streams
     except Exception as e:

--- a/Src/API/eurostreaming.py
+++ b/Src/API/eurostreaming.py
@@ -243,7 +243,7 @@ async def search(showname,date,season,episode,MFP,MFP_CREDENTIALS,client,streams
                     if match:
                         year = match.group(0)
             if abs(int(year) - int(date)) <=1:
-                streams = await episodes_find(description,season,episode,MFP,MFP_CREDENTIALS,client,streams)
+                streams = await episodes_find(description,link,headers,season,episode,MFP,MFP_CREDENTIALS,client,streams)
                 return streams
     return streams
 


### PR DESCRIPTION
Two independent crashes, each of which makes its provider return zero streams. Both are caught by broad `except Exception` handlers, so they surface only as a one-line warning in the log and look like "the site has no results" rather than a bug.

### 1. `eurostreaming` — wrong number of arguments

`episodes_find()` is defined with nine parameters, but the call in the year-match branch of `search()` passes seven, omitting `link` and `headers`. Every later argument shifts left and the call dies with:

```
episodes_find() missing 2 required positional arguments: 'client' and 'streams'
```

Eurostreaming therefore returns nothing whenever a title is matched by year instead of by name ratio. The other call site in the same function already passes all nine, and both `link` and `headers` are in scope, so this makes the two consistent.

### 2. `cb01` — unguarded "not found"

`search_series()` / `search_movie()` return `None` when nothing matches — the loop falls through, and their own `except` handlers also return `None`. `cb01()` passes that into `series_redirect_url()` / `movie_redirect_url()`, which do `ForwardProxy + link`:

```
can only concatenate str (not "NoneType") to str
```

"Not found" is a normal outcome, not an error, so this returns the streams unchanged and logs which title had no match. It is easy to hit because TMDB supplies localised titles that CB01 does not always index identically, e.g. `Desperate Housewives - I segreti di Wisteria Lane`.

### Verification

Self-hosted instance, Docker, arm64. The two fixes were verified to different depths, so to be precise about which is which:

**`cb01` — before and after.** Running unmodified `main` with CB01 as the only enabled provider, then this branch:

| title | before | after |
|---|---|---|
| Desperate Housewives S01E01 | `can only concatenate str (not "NoneType")` | `CB01: no series match for Desperate Housewives - I segreti di Wisteria Lane (2004)` |
| The Office S04E06 | `can only concatenate str (not "NoneType")` | `CB01: no series match for The Office (US) (2005)` |

**`eurostreaming` — before and after on one title.** Desperate Housewives S01E01 is the only case I observed reaching the year-match branch where the broken call lives; there the `missing 2 required positional arguments` warning is present before and absent after. The stronger evidence for this one is static rather than empirical: the definition takes nine required parameters, the call at the other site supplies nine, and the failing site supplied seven — checkable from the AST with no network access.

**Regression checks, after only.** Breaking Bad S01E01, The Shawshank Redemption and Inception return the same number of streams as before, and no `TypeError` appears in the logs for any of the titles above.

Neither fix makes a provider find anything it did not find already — they convert two crashes into accurate "no result" outcomes. In particular the cb01 change does not address the underlying title-matching problem, which is handled separately in #88.

Scope is deliberately narrow: no behaviour changes beyond not crashing.
