### PR TITLE
cb01: find shows whose TMDB title carries a subtitle or country tag

### DIFF
--- a/Src/API/cb01.py
+++ b/Src/API/cb01.py
@@ -197,7 +197,6 @@ async def series_search_streams(text,search_text,response_text,headers,season,ep
             response = await client.get(ForwardProxy + captcha.group(1), headers = headers, allow_redirects = True, proxies = proxies)
             season = season.zfill(2)
             match = re.search(rf"(S{season}E{episode}|{season}x{episode}).+?href='([^']+)",response.text)
-            print(match.group(2))
             if match:
                 streams = await get_maxstream(match.group(2),streams,client)
     else:

--- a/Src/API/cb01.py
+++ b/Src/API/cb01.py
@@ -89,63 +89,92 @@ async def get_maxstream(link,streams,client):
             streams['streams'].append({'name': f"{Name}",'title': f'{Icon}CB01\n▶️ Please do the captcha at /uprot in order to be able to play this content! \n Remember to refresh the sources!\nIf you recently did the captcha then dont worry, just refresh the sources', 'url': 'https://github.com/UrloMythus/MammaMia', 'behaviorHints': { 'bingeGroup': 'cb01'}})
 
     return streams
+def title_variants(showname):
+    """Yield search queries to try for a title, most specific first.
+
+    TMDB returns titles that carry extra text the site does not index:
+
+      "Desperate Housewives - I segreti di Wisteria Lane"  -> "Desperate Housewives"
+      "The Office (US)"                                    -> "The Office"
+
+    CB01 lists the short forms, so searching the full string returns nothing.
+    Try the exact title first, then progressively simpler forms.
+
+    The caller still checks the release year of every candidate result, so a
+    broader query cannot silently match an unrelated show - "The Office" finds
+    both the 2005 US and 2001 UK series, and the year check picks the right one.
+    """
+    variants = [showname]
+    for separator in (" - ", " \u2013 ", ": "):
+        if separator in showname:
+            head = showname.split(separator)[0].strip()
+            if head and head not in variants:
+                variants.append(head)
+    without_parenthetical = re.sub(r"\s*\([^)]*\)\s*$", "", showname).strip()
+    if without_parenthetical and without_parenthetical not in variants:
+        variants.append(without_parenthetical)
+    return variants
+
+
+
 async def search_movie(showname,date,client):
     try:
-        showname = showname.replace(" ","+").replace("ò","o").replace("è","e").replace("à","a").replace("ù","u").replace("ì","i")  
         headers = fake_headers.generate()
         headers['Referer'] = f'{CB_DOMAIN}/'
-        query = f'{CB_DOMAIN}/?s={showname}'
-        response = await client.get(ForwardProxy + query,headers=headers, proxies = proxies)
-        if response.status_code != 200:
-            logger.warning(f"CB01 Failed to fetch search results: {response.status_code}")
-        soup = BeautifulSoup(response.text, 'lxml',parse_only=SoupStrainer('div', class_='card-content'))
-        cards = soup.find_all('div', class_='card-content')
         year_pattern = re.compile(r'(19|20)\d{2}')
-        for card in cards:
-    # Find the link inside the current card
-            link_tag = card.find('h3', class_='card-title').find('a')
-            href = link_tag['href']
-    # Find the date span and extract possible years
-
-            date_text = href.split("/")[-2]
+        for candidate in title_variants(showname):
+            candidate = candidate.replace(" ","+").replace("\u00f2","o").replace("\u00e8","e").replace("\u00e0","a").replace("\u00f9","u").replace("\u00ec","i")
+            query = f'{CB_DOMAIN}/?s={candidate}'
+            response = await client.get(ForwardProxy + query,headers=headers, proxies = proxies)
+            if response.status_code != 200:
+                logger.warning(f"CB01 Failed to fetch search results: {response.status_code}")
+            soup = BeautifulSoup(response.text, 'lxml',parse_only=SoupStrainer('div', class_='card-content'))
+            cards = soup.find_all('div', class_='card-content')
+            for card in cards:
+                # Find the link inside the current card
+                link_tag = card.find('h3', class_='card-title').find('a')
+                href = link_tag['href']
+                # Find the date span and extract possible years
+                date_text = href.split("/")[-2]
                 # Search for the first occurrence of a year (starting with 19 or 20)
-            match = year_pattern.search(date_text)
-            if match:
-                year = match.group(0)
-                if year == date :
-                    return href
+                match = year_pattern.search(date_text)
+                if match:
+                    year = match.group(0)
+                    if year == date :
+                        return href
     except Exception as e:
         logger.warning(f'MammaMia: Error in search_series cb01: {e}')
 
 
 async def search_series(showname,date,client):
     try:
-        showname = showname.replace(" ","+")
         headers = fake_headers.generate()
         headers['Referer'] = f'{CB_DOMAIN}/serietv/'
-        query = f'{CB_DOMAIN}/serietv/?s={showname}'
-        response = await client.get(ForwardProxy + query,headers=headers, proxies = proxies)
-        if response.status_code != 200:
-            logger.warning(f"CB01 Failed to fetch search results: {response.status_code}")
-        soup = BeautifulSoup(response.text, 'lxml',parse_only=SoupStrainer('div', class_='card-content'))
-        cards = soup.find_all('div', class_='card-content')
         year_pattern = re.compile(r'(19|20)\d{2}')
-        for card in cards:
-    # Find the link inside the current card
-            link_tag = card.find('h3', class_='card-title').find('a')
-            href = link_tag['href']
-    # Find the date span and extract possible years
-            date_span = card.find('span', style=re.compile('color'))
-            if date_span:
-                date_text = date_span.text
-                # Search for the first occurrence of a year (starting with 19 or 20)
-                match = year_pattern.search(date_text)
-                if match:
-                    year = match.group(0)
-                    if (int(year) - int(date)) == 0 or (int(year)-int(date)) == 1 or (int(year)-int(date)) == -1 :  # Check if the year is 2011
-                        return href
+        for candidate in title_variants(showname):
+            query = f'{CB_DOMAIN}/serietv/?s={candidate.replace(" ","+")}'
+            response = await client.get(ForwardProxy + query,headers=headers, proxies = proxies)
+            if response.status_code != 200:
+                logger.warning(f"CB01 Failed to fetch search results: {response.status_code}")
+            soup = BeautifulSoup(response.text, 'lxml',parse_only=SoupStrainer('div', class_='card-content'))
+            cards = soup.find_all('div', class_='card-content')
+            for card in cards:
+                # Find the link inside the current card
+                link_tag = card.find('h3', class_='card-title').find('a')
+                href = link_tag['href']
+                # Find the date span and extract possible years
+                date_span = card.find('span', style=re.compile('color'))
+                if date_span:
+                    date_text = date_span.text
+                    # Search for the first occurrence of a year (starting with 19 or 20)
+                    match = year_pattern.search(date_text)
+                    if match:
+                        year = match.group(0)
+                        if (int(year) - int(date)) == 0 or (int(year)-int(date)) == 1 or (int(year)-int(date)) == -1 :
+                            return href
     except Exception as e:
         logger.warning(f'MammaMia: Error in search_series cb01: {e}')
+
 
 async def movie_redirect_url(link,client,MFP,MFP_CREDENTIALS,streams):
         headers = fake_headers.generate()


### PR DESCRIPTION
CB01 often has a show but never finds it, because the search is issued with the title exactly as TMDB returns it. Measured against the live site:

| query | results |
|---|---|
| `Desperate Housewives - I segreti di Wisteria Lane` | 0 |
| `Desperate Housewives` | 1 |
| `The Office (US)` | 0 |
| `The Office` | 3 |

### Commit 1 — retry with a simplified title

`title_variants()` yields the exact title first, then the part before a `" - "` / `" – "` / `": "` separator, then the title without a trailing parenthetical. A title needing no simplification produces a single candidate, so the common case still issues exactly one request.

This cannot silently match the wrong show: both callers already require a candidate's release year to match (`search_movie` exactly, `search_series` within ±1). Searching `The Office` returns the 2005 US and 2001 UK series, and that existing check keeps the right one.

### Commit 2 — a latent crash the first commit exposes

`series_search_streams()` had:

```python
match = re.search(...)
print(match.group(2))
if match:
```

The debug `print` sits above the `if match:` guard meant to protect it, raising `'NoneType' object has no attribute 'group'` whenever the episode link is absent. It was mostly unreachable while the search failed earlier and returned `None`. Once CB01 starts finding shows it becomes easy to hit — e.g. The Office S04E06, where the series page is found but that episode's link is not.

### Measured before/after

Self-hosted instance (Docker, arm64), CB01 as the only enabled provider, same five titles, `main` unmodified vs this branch:

| title | before | after |
|---|---|---|
| Desperate Housewives S01E01 | 0 (`TypeError`) | **1** |
| The Office S04E06 | 0 (`TypeError`) | 0, no crash |
| Breaking Bad S01E01 | 1 | 1 |
| The Shawshank Redemption | 1 | 1 |
| Inception | 1 | 1 |

One title gains a stream, two crashes disappear, and no title regresses.

The Office still returns nothing: CB01 now finds the series, but that page lists the episode as a double `S04E05-E06` entry which the episode regex does not match. That is a separate problem and is left alone here.

### Scope and limitations

Only the two search helpers change; matching strictness is unchanged. Simplification is not recursive, so a title combining both forms — `Shameless (US) - Vergogna` — yields `Shameless (US)` but never plain `Shameless`. That could be extended, at the cost of another request per lookup.

The `TypeError` in the before column is the same one fixed by #87, from a different direction: that PR guards the `None` return, this one stops the search returning `None` for titles the site actually has. They are independent and touch different functions.
